### PR TITLE
fix: add parameterized queries in sign_up.php

### DIFF
--- a/sign_up.php
+++ b/sign_up.php
@@ -25,11 +25,15 @@ include('./_Partial Components/link.php');
                 $Image = $_FILES['image']['name'];
                 $Image_tmp = $_FILES['image']['tmp_name'];
 
-                $chk_user = "select * from Users where Username = '$Username'";
-                $chk_run_user = mysqli_query($con, $chk_user);
+			$chk_stmt = mysqli_prepare($con, "SELECT * FROM Users WHERE Username = ?");
+				mysqli_stmt_bind_param($chk_stmt, "s", $Username);
+				mysqli_stmt_execute($chk_stmt);
+				$chk_run_user = mysqli_stmt_get_result($chk_stmt);
 
-                $chk_email = "select * from Users where Email = '$Email'";
-                $chk_run_email = mysqli_query($con, $chk_email);
+				$chk_email_stmt = mysqli_prepare($con, "SELECT * FROM Users WHERE Email = ?");
+				mysqli_stmt_bind_param($chk_email_stmt, "s", $Email);
+				mysqli_stmt_execute($chk_email_stmt);
+				$chk_run_email = mysqli_stmt_get_result($chk_email_stmt);
 
                 if(empty($Full_Name) or empty($Username) or empty($Password) or empty($Email) or empty($Gender) or empty($Phone_No) or empty($Image)){
                     $error = "All fields required";
@@ -45,8 +49,9 @@ include('./_Partial Components/link.php');
                     $error_email = "Email Already exist try new one";
                  }
                 else{
-                    $insert_query = "insert into Users(Full_Name, Username, Password, Email, Language, Gender, Phone_No, Image) values('$Full_Name', '$Username', '$Password', '$Email', 'English', '$Gender', '$Phone_No', '$Image')";
-                    if(mysqli_query($con, $insert_query)){
+				$insert_stmt = mysqli_prepare($con, "INSERT INTO Users(Full_Name, Username, Password, Email, Language, Gender, Phone_No, Image) VALUES(?, ?, ?, ?, 'English', ?, ?, ?)");
+					mysqli_stmt_bind_param($insert_stmt, "sssssss", $Full_Name, $Username, $Password, $Email, $Gender, $Phone_No, $Image);
+					if(mysqli_stmt_execute($insert_stmt)){
                         move_uploaded_file($Image_tmp, "assets/img/_ProfilePicture/$Image");
                         $msg = "Registration Successfull";
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `sign_up.php`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `sign_up.php:28` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-89 |

**Description**: The user registration form directly concatenates the Username parameter into a SQL query without proper parameterization. Although mysqli_real_escape_string() is applied, this provides insufficient protection against SQL injection in all contexts, allowing attackers to inject arbitrary SQL code.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `sign_up.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
